### PR TITLE
Change EnumFromString

### DIFF
--- a/lib/src/readers/navigation_reader.dart
+++ b/lib/src/readers/navigation_reader.dart
@@ -342,7 +342,7 @@ class NavigationReader {
           result.Value = attributeValue;
           break;
         case "type":
-          var converter = new EnumFromString<EpubNavigationPageTargetType>();
+          var converter = new EnumFromString<EpubNavigationPageTargetType>(EpubNavigationPageTargetType.values);
           EpubNavigationPageTargetType type = converter.get(attributeValue);
           result.Type = type;
           break;

--- a/lib/src/utils/enum_from_string.dart
+++ b/lib/src/utils/enum_from_string.dart
@@ -1,11 +1,18 @@
-import 'dart:mirrors';
 
 class EnumFromString<T> {
+  List<T> enumValues;
+
+  EnumFromString(List<T> this.enumValues);
+
   T get(String value) {
-    return (reflectType(T) as ClassMirror)
-        .getField(#values)
-        .reflectee
-        .firstWhere((e) =>
-            e.toString().split('.')[1].toUpperCase() == value.toUpperCase());
+    value = "$T.$value";
+    try {
+      var x = this.enumValues
+          .firstWhere((f)=>
+              f.toString().toUpperCase() == value.toUpperCase());
+      return x;
+    } catch(e) {
+      return null;
+    }
   }
 }

--- a/test/enum_string_test.dart
+++ b/test/enum_string_test.dart
@@ -6,16 +6,16 @@ import 'package:epub/epub.dart';
 
 main() {
   test("Enum One", () {
-    expect(new EnumFromString<Simple>().get("ONE"), equals(Simple.ONE));
+    expect(new EnumFromString<Simple>(Simple.values).get("ONE"), equals(Simple.ONE));
   });
   test("Enum Two", () {
-    expect(new EnumFromString<Simple>().get("TWO"), equals(Simple.TWO));
+    expect(new EnumFromString<Simple>(Simple.values).get("TWO"), equals(Simple.TWO));
   });
   test("Enum One", () {
-    expect(new EnumFromString<Simple>().get("THREE"), equals(Simple.THREE));
+    expect(new EnumFromString<Simple>(Simple.values).get("THREE"), equals(Simple.THREE));
   });
   test("Enum One Lower Case", () {
-    expect(new EnumFromString<Simple>().get("one"), equals(Simple.ONE));
+    expect(new EnumFromString<Simple>(Simple.values).get("one"), equals(Simple.ONE));
   });
 }
 


### PR DESCRIPTION
Change: Changed EnumFromString Class to work without the need of dart:mirrors.

Purpose: Now works with Flutter.