### PR TITLE
Opf namespace bug

### DIFF
--- a/lib/src/readers/package_reader.dart
+++ b/lib/src/readers/package_reader.dart
@@ -224,7 +224,7 @@ class PackageReader {
         case "id":
           result.Id = attributeValue;
           break;
-        case "opf:scheme":
+        case "scheme":
           result.Scheme = attributeValue;
           break;
       }


### PR DESCRIPTION
I found this bug when using it's internal library extensively, this namespace indicator should not be here