### PR TITLE
Do not depend on (private) inner packages of dart-xml.

### DIFF
--- a/lib/src/writers/epub_guide_writer.dart
+++ b/lib/src/writers/epub_guide_writer.dart
@@ -1,5 +1,5 @@
 import 'package:epub/src/schema/opf/epub_guide.dart';
-import 'package:xml/xml/builder.dart';
+import 'package:xml/xml.dart' show XmlBuilder;
 
 class EpubGuideWriter {
   static void writeGuide(XmlBuilder builder, EpubGuide guide) {

--- a/lib/src/writers/epub_manifest_writer.dart
+++ b/lib/src/writers/epub_manifest_writer.dart
@@ -1,5 +1,5 @@
 import 'package:epub/src/schema/opf/epub_manifest.dart';
-import 'package:xml/xml/builder.dart';
+import 'package:xml/xml.dart' show XmlBuilder;
 
 class EpubManifestWriter {
   static void writeManifest(XmlBuilder builder, EpubManifest manifest) {

--- a/lib/src/writers/epub_metadata_writer.dart
+++ b/lib/src/writers/epub_metadata_writer.dart
@@ -1,6 +1,6 @@
 import 'package:epub/src/schema/opf/epub_metadata.dart';
 import 'package:epub/src/schema/opf/epub_version.dart';
-import 'package:xml/xml/builder.dart';
+import 'package:xml/xml.dart' show XmlBuilder;
 
 class EpubMetadataWriter {
   static const _dc_namespace = "http://purl.org/dc/elements/1.1/";

--- a/lib/src/writers/epub_package_writer.dart
+++ b/lib/src/writers/epub_package_writer.dart
@@ -3,7 +3,7 @@ import 'package:epub/src/schema/opf/epub_version.dart';
 import 'package:epub/src/writers/epub_guide_writer.dart';
 import 'package:epub/src/writers/epub_manifest_writer.dart';
 import 'package:epub/src/writers/epub_spine_writer.dart';
-import 'package:xml/xml/builder.dart';
+import 'package:xml/xml.dart' show XmlBuilder;
 import 'epub_metadata_writer.dart';
 
 class EpubPackageWriter {

--- a/lib/src/writers/epub_spine_writer.dart
+++ b/lib/src/writers/epub_spine_writer.dart
@@ -1,5 +1,5 @@
 import 'package:epub/src/schema/opf/epub_spine.dart';
-import 'package:xml/xml/builder.dart';
+import 'package:xml/xml.dart' show XmlBuilder;
 
 class EpubSpineWriter {
   static void writeSpine(XmlBuilder builder, EpubSpine spine) {


### PR DESCRIPTION
I noticed that your package depends on some (private) inner packages of dart-xml. The next release of dart-xml would break your code, because I changed the internal package structure to match the Dart guidelines. This change simply imports the main library, and only shows the desired builder class.