### PR TITLE
Closes issue #35: File cannot be opened if its path is url-encoded in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Fixed Issue #35: File cannot be opened if its path is url-encoded in the manifest
 
 ## [2.0.5] - 2019-05-16
 ### Changed

--- a/lib/src/readers/content_reader.dart
+++ b/lib/src/readers/content_reader.dart
@@ -32,7 +32,7 @@ class ContentReader {
           EpubTextContentFileRef epubTextContentFile =
               new EpubTextContentFileRef(bookRef);
           {
-            epubTextContentFile.FileName = fileName;
+            epubTextContentFile.FileName = Uri.decodeFull(fileName);
             epubTextContentFile.ContentMimeType = contentMimeType;
             epubTextContentFile.ContentType = contentType;
           }
@@ -64,7 +64,7 @@ class ContentReader {
           EpubByteContentFileRef epubByteContentFile =
               new EpubByteContentFileRef(bookRef);
           {
-            epubByteContentFile.FileName = fileName;
+            epubByteContentFile.FileName = Uri.decodeFull(fileName);
             epubByteContentFile.ContentMimeType = contentMimeType;
             epubByteContentFile.ContentType = contentType;
           }


### PR DESCRIPTION
… the manifest

Adds calls to `Uri.decodeFull` to de-encode the fileName for EpubContent