### PR TITLE
urldecoded contentFileName

### DIFF
--- a/lib/src/readers/chapter_reader.dart
+++ b/lib/src/readers/chapter_reader.dart
@@ -28,7 +28,7 @@ class ChapterReader {
         anchor = navigationPoint.Content.Source
             .substring(contentSourceAnchorCharIndex + 1);
       }
-
+      contentFileName = Uri.decodeFull(contentFileName);
       EpubTextContentFileRef htmlContentFileRef;
       if (!bookRef.Content.Html.containsKey(contentFileName)) {
         throw Exception(


### PR DESCRIPTION
bug fix #71 : parse fail when 'contentFileName' contain urlencoded coding
