### PR TITLE
Update xml dependency to 4.2.0

### DIFF
--- a/lib/src/readers/chapter_reader.dart
+++ b/lib/src/readers/chapter_reader.dart
@@ -33,14 +33,7 @@ class ChapterReader {
       if (!bookRef.Content.Html.containsKey(contentFileName)) {
         // It shouldn't be an encoded url, but we can handle it if it is.
         final decodedFileName = Uri.decodeFull(contentFileName);
-        if (!bookRef.Content.Html.containsKey(decoded)) {
-            throw Exception("Incorrect EPUB manifest: item with href = \"${contentFileName}\" is missing.");
-        }
-        
-        contentFileName = decodedFileName
-        if (bookRef.Content.Html.containsKey(decoded)) {
-          contentFileName = decoded;
-        } else {
+        if (!bookRef.Content.Html.containsKey(decodedFileName)) {
           throw Exception(
               "Incorrect EPUB manifest: item with href = \"${contentFileName}\" is missing.");
         }

--- a/lib/src/readers/chapter_reader.dart
+++ b/lib/src/readers/chapter_reader.dart
@@ -32,7 +32,12 @@ class ChapterReader {
       EpubTextContentFileRef htmlContentFileRef;
       if (!bookRef.Content.Html.containsKey(contentFileName)) {
         // It shouldn't be an encoded url, but we can handle it if it is.
-        final decoded = Uri.decodeFull(contentFileName);
+        final decodedFileName = Uri.decodeFull(contentFileName);
+        if (!bookRef.Content.Html.containsKey(decoded)) {
+            throw Exception("Incorrect EPUB manifest: item with href = \"${contentFileName}\" is missing.");
+        }
+        
+        contentFileName = decodedFileName
         if (bookRef.Content.Html.containsKey(decoded)) {
           contentFileName = decoded;
         } else {

--- a/lib/src/readers/chapter_reader.dart
+++ b/lib/src/readers/chapter_reader.dart
@@ -31,8 +31,14 @@ class ChapterReader {
 
       EpubTextContentFileRef htmlContentFileRef;
       if (!bookRef.Content.Html.containsKey(contentFileName)) {
-        throw Exception(
-            "Incorrect EPUB manifest: item with href = \"${contentFileName}\" is missing.");
+        // It shouldn't be an encoded url, but we can handle it if it is.
+        final decoded = Uri.decodeFull(contentFileName);
+        if (bookRef.Content.Html.containsKey(decoded)) {
+          contentFileName = decoded;
+        } else {
+          throw Exception(
+              "Incorrect EPUB manifest: item with href = \"${contentFileName}\" is missing.");
+        }
       }
 
       htmlContentFileRef = bookRef.Content.Html[contentFileName];

--- a/lib/src/readers/chapter_reader.dart
+++ b/lib/src/readers/chapter_reader.dart
@@ -31,12 +31,8 @@ class ChapterReader {
       contentFileName = Uri.decodeFull(contentFileName);
       EpubTextContentFileRef htmlContentFileRef;
       if (!bookRef.Content.Html.containsKey(contentFileName)) {
-        // It shouldn't be an encoded url, but we can handle it if it is.
-        final decodedFileName = Uri.decodeFull(contentFileName);
-        if (!bookRef.Content.Html.containsKey(decodedFileName)) {
-          throw Exception(
-              "Incorrect EPUB manifest: item with href = \"${contentFileName}\" is missing.");
-        }
+        throw Exception(
+            "Incorrect EPUB manifest: item with href = \"${contentFileName}\" is missing.");
       }
 
       htmlContentFileRef = bookRef.Content.Html[contentFileName];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: epub
-version: 2.1.0
+version: 2.1.1
 author: Colin Nelson <colin@orthros.dev>
 description: Epub Parser for Dart. Suitable for use on the Server, the Web, or in Flutter
 homepage: https://github.com/orthros/dart-epub


### PR DESCRIPTION
Addresses issue #74 

Xml dependency can be upgraded to 4.2.0 and all the tests still pass (via `dart pub test`).