### PR TITLE
Fix hashcode computation

### DIFF
--- a/lib/src/entities/epub_book.dart
+++ b/lib/src/entities/epub_book.dart
@@ -16,15 +16,17 @@ class EpubBook {
   List<EpubChapter> Chapters;
 
   @override
-  int get hashCode => hashObjects([
-        Title.hashCode,
-        Author.hashCode,
-        AuthorList.hashCode,
-        Schema.hashCode,
-        Content.hashCode,
-        CoverImage.hashCode,
-        Chapters.hashCode
-      ]);
+  int get hashCode {
+    var objects = []
+      ..add(Title.hashCode)
+      ..add(Author.hashCode)
+      ..add(Schema.hashCode)
+      ..add(Content.hashCode)
+      ..add(CoverImage.hashCode)
+      ..addAll(AuthorList?.map((author) => author.hashCode) ?? [0])
+      ..addAll(Chapters?.map((chapter) => chapter.hashCode) ?? [0]);
+    return hashObjects(objects);
+  }
 
   bool operator ==(other) {
     var otherAs = other as EpubBook;

--- a/lib/src/entities/epub_book.dart
+++ b/lib/src/entities/epub_book.dart
@@ -22,7 +22,7 @@ class EpubBook {
       ..add(Author.hashCode)
       ..add(Schema.hashCode)
       ..add(Content.hashCode)
-      ..add(CoverImage.hashCode)
+      ..addAll(CoverImage?.getBytes()?.map((byte) => byte.hashCode) ?? [0])
       ..addAll(AuthorList?.map((author) => author.hashCode) ?? [0])
       ..addAll(Chapters?.map((chapter) => chapter.hashCode) ?? [0]);
     return hashObjects(objects);

--- a/lib/src/entities/epub_byte_content_file.dart
+++ b/lib/src/entities/epub_byte_content_file.dart
@@ -7,8 +7,14 @@ class EpubByteContentFile extends EpubContentFile {
   List<int> Content;
 
   @override
-  int get hashCode => hash4(Content.hashCode, ContentMimeType.hashCode,
-      ContentType.hashCode, FileName.hashCode);
+  int get hashCode {
+    var objects = []
+      ..add(ContentMimeType.hashCode)
+      ..add(ContentType.hashCode)
+      ..add(FileName.hashCode)
+      ..addAll(Content?.map((content) => content.hashCode) ?? [0]);
+    return hashObjects(objects);
+  }
 
   bool operator ==(other) {
     var otherAs = other as EpubByteContentFile;

--- a/lib/src/entities/epub_chapter.dart
+++ b/lib/src/entities/epub_chapter.dart
@@ -9,13 +9,15 @@ class EpubChapter {
   List<EpubChapter> SubChapters;
 
   @override
-  int get hashCode => hashObjects([
-        Title.hashCode,
-        ContentFileName.hashCode,
-        Anchor.hashCode,
-        HtmlContent.hashCode,
-        SubChapters.hashCode
-      ]);
+  int get hashCode {
+    var objects = []
+      ..add(Title.hashCode)
+      ..add(ContentFileName.hashCode)
+      ..add(Anchor.hashCode)
+      ..add(HtmlContent.hashCode)
+      ..addAll(SubChapters?.map((subChapter) => subChapter.hashCode) ?? [0]);
+    return hashObjects(objects);
+  }
 
   bool operator ==(other) {
     var otherAs = other as EpubChapter;

--- a/lib/src/ref_entities/epub_book_ref.dart
+++ b/lib/src/ref_entities/epub_book_ref.dart
@@ -24,13 +24,15 @@ class EpubBookRef {
   }
 
   @override
-  int get hashCode => hashObjects([
-        Title.hashCode,
-        Author.hashCode,
-        AuthorList.hashCode,
-        Schema.hashCode,
-        Content.hashCode
-      ]);
+  int get hashCode {
+    var objects = []
+      ..add(Title.hashCode)
+      ..add(Author.hashCode)
+      ..add(Schema.hashCode)
+      ..add(Content.hashCode)
+      ..addAll(AuthorList?.map((author) => author.hashCode) ?? [0]);
+    return hashObjects(objects);
+  }
 
   bool operator ==(other) {
     var otherAs = other as EpubBookRef;

--- a/lib/src/ref_entities/epub_chapter_ref.dart
+++ b/lib/src/ref_entities/epub_chapter_ref.dart
@@ -18,13 +18,15 @@ class EpubChapterRef {
   }
 
   @override
-  int get hashCode => hashObjects([
-        Title.hashCode,
-        ContentFileName.hashCode,
-        Anchor.hashCode,
-        epubTextContentFileRef.hashCode,
-        SubChapters.hashCode
-      ]);
+  int get hashCode {
+    var objects = []
+      ..add(Title.hashCode)
+      ..add(ContentFileName.hashCode)
+      ..add(Anchor.hashCode)
+      ..add(epubTextContentFileRef.hashCode)
+      ..addAll(SubChapters?.map((subChapter) => subChapter.hashCode) ?? [0]);
+    return hashObjects(objects);
+  }
 
   bool operator ==(other) {
     var otherAs = other as EpubChapterRef;

--- a/lib/src/schema/navigation/epub_navigation.dart
+++ b/lib/src/schema/navigation/epub_navigation.dart
@@ -17,14 +17,16 @@ class EpubNavigation {
   List<EpubNavigationList> NavLists;
 
   @override
-  int get hashCode => hashObjects([
-        Head.hashCode,
-        DocTitle.hashCode,
-        DocAuthors.hashCode,
-        NavMap.hashCode,
-        PageList.hashCode,
-        NavLists.hashCode
-      ]);
+  int get hashCode {
+    var objects = []
+      ..add(Head.hashCode)
+      ..add(DocTitle.hashCode)
+      ..add(NavMap.hashCode)
+      ..add(PageList.hashCode)
+      ..addAll(DocAuthors?.map((author) => author.hashCode) ?? [0])
+      ..addAll(NavLists?.map((navList) => navList.hashCode) ?? [0]);
+    return hashObjects(objects);
+  }
 
   bool operator ==(other) {
     var otherAs = other as EpubNavigation;

--- a/lib/src/schema/navigation/epub_navigation_list.dart
+++ b/lib/src/schema/navigation/epub_navigation_list.dart
@@ -11,8 +11,14 @@ class EpubNavigationList {
   List<EpubNavigationTarget> NavigationTargets;
 
   @override
-  int get hashCode => hash4(Id.hashCode, Class.hashCode,
-      NavigationLabels.hashCode, NavigationTargets.hashCode);
+  int get hashCode {
+    var objects = []
+      ..add(Id.hashCode)
+      ..add(Class.hashCode)
+      ..addAll(NavigationLabels?.map((label) => label.hashCode) ?? [0])
+      ..addAll(NavigationTargets?.map((target) => target.hashCode) ?? [0]);
+    return hashObjects(objects);
+  }
 
   bool operator ==(other) {
     var otherAs = other as EpubNavigationList;

--- a/lib/src/schema/navigation/epub_navigation_map.dart
+++ b/lib/src/schema/navigation/epub_navigation_map.dart
@@ -1,4 +1,5 @@
 import 'package:quiver/collection.dart' as collections;
+import 'package:quiver/core.dart';
 
 import 'epub_navigation_point.dart';
 
@@ -6,7 +7,9 @@ class EpubNavigationMap {
   List<EpubNavigationPoint> Points;
 
   @override
-  int get hashCode => Points.hashCode;
+  int get hashCode {
+    return hashObjects(Points?.map((point) => point.hashCode) ?? [0]);
+  }
 
   bool operator ==(other) {
     var otherAs = other as EpubNavigationMap;

--- a/lib/src/schema/navigation/epub_navigation_page_list.dart
+++ b/lib/src/schema/navigation/epub_navigation_page_list.dart
@@ -1,4 +1,5 @@
 import 'package:quiver/collection.dart' as collections;
+import 'package:quiver/core.dart';
 
 import 'epub_navigation_page_target.dart';
 
@@ -6,7 +7,9 @@ class EpubNavigationPageList {
   List<EpubNavigationPageTarget> Targets;
 
   @override
-  int get hashCode => Targets.hashCode;
+  int get hashCode {
+    return hashObjects(Targets?.map((target) => target.hashCode) ?? [0]);
+  }
 
   bool operator ==(other) {
     var otherAs = other as EpubNavigationPageList;

--- a/lib/src/schema/navigation/epub_navigation_page_target.dart
+++ b/lib/src/schema/navigation/epub_navigation_page_target.dart
@@ -15,15 +15,17 @@ class EpubNavigationPageTarget {
   EpubNavigationContent Content;
 
   @override
-  int get hashCode => hashObjects([
-        Id.hashCode,
-        Value.hashCode,
-        Type.hashCode,
-        Class.hashCode,
-        PlayOrder.hashCode,
-        NavigationLabels.hashCode,
-        Content.hashCode
-      ]);
+  int get hashCode {
+    var objects = []
+      ..add(Id.hashCode)
+      ..add(Value.hashCode)
+      ..add(Type.hashCode)
+      ..add(Class.hashCode)
+      ..add(PlayOrder.hashCode)
+      ..add(Content.hashCode)
+      ..addAll(NavigationLabels?.map((label) => label.hashCode) ?? [0]);
+    return hashObjects(objects);
+  }
 
   bool operator ==(other) {
     var otherAs = other as EpubNavigationPageTarget;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,7 +9,7 @@ dependencies:
   async: ">=1.8.0 <3.0.0"
   archive: "^2.0.0"
   quiver: ">=2.0.0 <3.0.0"
-  xml: ">=2.6.0 <4.0.0"
+  xml: "^4.2.0"
   image: ">=1.1.33 <3.0.0"
   dart2_constant: ^1.0.1
 dev_dependencies:

--- a/test/entities/epub_book_test.dart
+++ b/test/entities/epub_book_test.dart
@@ -19,13 +19,13 @@ main() async {
   setUp(() async {
     testBook = new EpubBook();
     testBook
-      ..Author = reference.Author
-      ..AuthorList = reference.AuthorList
-      ..Chapters = reference.Chapters
-      ..Content = reference.Content
-      ..CoverImage = reference.CoverImage
-      ..Schema = reference.Schema
-      ..Title = reference.Title;
+      ..Author = "orthros"
+      ..AuthorList = ["orthros"]
+      ..Chapters = [new EpubChapter()]
+      ..Content = new EpubContent()
+      ..CoverImage = Image(100, 100)
+      ..Schema = new EpubSchema()
+      ..Title = "A Dissertation on Epubs";
   });
   tearDown(() async {
     testBook = null;

--- a/test/entities/epub_byte_content_file_test.dart
+++ b/test/entities/epub_byte_content_file_test.dart
@@ -16,10 +16,10 @@ main() async {
   setUp(() async {
     testFile = new EpubByteContentFile();
     testFile
-      ..Content = reference.Content
-      ..ContentMimeType = reference.ContentMimeType
-      ..ContentType = reference.ContentType
-      ..FileName = reference.FileName;
+      ..Content = [0, 1, 2, 3]
+      ..ContentMimeType = "application/test"
+      ..ContentType = EpubContentType.OTHER
+      ..FileName = "orthrosFile";
   });
 
   tearDown(() async {

--- a/test/entities/epub_chapter_test.dart
+++ b/test/entities/epub_chapter_test.dart
@@ -16,11 +16,11 @@ main() async {
   setUp(() async {
     testChapter = new EpubChapter();
     testChapter
-      ..Anchor = reference.Anchor
-      ..ContentFileName = reference.ContentFileName
-      ..HtmlContent = reference.HtmlContent
-      ..SubChapters = reference.SubChapters
-      ..Title = reference.Title;
+      ..Anchor = "anchor"
+      ..ContentFileName = "orthros"
+      ..HtmlContent = "<html></html>"
+      ..SubChapters = []
+      ..Title = "A New Look at Chapters";
   });
   tearDown(() async {
     testChapter = null;

--- a/test/entities/epub_schema_test.dart
+++ b/test/entities/epub_schema_test.dart
@@ -20,9 +20,10 @@ main() async {
   setUp(() async {
     testSchema = new EpubSchema();
     testSchema
-      ..Package = reference.Package
-      ..Navigation = reference.Navigation
-      ..ContentDirectoryPath = reference.ContentDirectoryPath;
+      ..Package = new EpubPackage()
+      ..Navigation = new EpubNavigation()
+      ..ContentDirectoryPath = "some/random/path";
+    testSchema.Package.Version = EpubVersion.Epub2;
   });
   tearDown(() async {
     testSchema = null;

--- a/test/entities/epub_text_content_file_test.dart
+++ b/test/entities/epub_text_content_file_test.dart
@@ -14,10 +14,10 @@ main() async {
   setUp(() async {
     testFile = new EpubTextContentFile();
     testFile
-      ..Content = reference.Content
-      ..ContentMimeType = reference.ContentMimeType
-      ..ContentType = reference.ContentType
-      ..FileName = reference.FileName;
+      ..Content = "Hello"
+      ..ContentMimeType = "application/test"
+      ..ContentType = EpubContentType.OTHER
+      ..FileName = "orthrosFile";
   });
   tearDown(() async {
     testFile = null;

--- a/test/ref_entities/epub_book_ref_test.dart
+++ b/test/ref_entities/epub_book_ref_test.dart
@@ -20,11 +20,10 @@ main() async {
   setUp(() async {
     testBookRef = new EpubBookRef(arch);
     testBookRef
-      ..Author = reference.Author
-      ..AuthorList = reference.AuthorList
-      ..Content = reference.Content
-      ..Schema = reference.Schema
-      ..Title = reference.Title;
+      ..Author = "orthros"
+      ..AuthorList = ["orthros"]
+      ..Schema = new EpubSchema()
+      ..Title = "A Dissertation on Epubs";
   });
   tearDown(() async {
     testBookRef = null;

--- a/test/ref_entities/epub_byte_content_file_ref_test.dart
+++ b/test/ref_entities/epub_byte_content_file_ref_test.dart
@@ -23,9 +23,9 @@ main() async {
 
     testFileRef = new EpubByteContentFileRef(ref2);
     testFileRef
-      ..ContentMimeType = reference.ContentMimeType
-      ..ContentType = reference.ContentType
-      ..FileName = reference.FileName;
+      ..ContentMimeType = "application/test"
+      ..ContentType = EpubContentType.OTHER
+      ..FileName = "orthrosFile";
   });
 
   tearDown(() async {

--- a/test/ref_entities/epub_chapter_ref_test.dart
+++ b/test/ref_entities/epub_chapter_ref_test.dart
@@ -27,10 +27,10 @@ main() async {
 
     testChapterRef = new EpubChapterRef(contentFileRef2);
     testChapterRef
-      ..Anchor = reference.Anchor
-      ..ContentFileName = reference.ContentFileName
-      ..SubChapters = reference.SubChapters
-      ..Title = reference.Title;
+      ..Anchor = "anchor"
+      ..ContentFileName = "orthros"
+      ..SubChapters = []
+      ..Title = "A New Look at Chapters";
   });
 
   tearDown(() async {

--- a/test/ref_entities/epub_text_content_file_ref_test.dart
+++ b/test/ref_entities/epub_text_content_file_ref_test.dart
@@ -22,9 +22,9 @@ main() async {
 
     testFile = new EpubTextContentFileRef(epubRef2);
     testFile
-      ..ContentMimeType = reference.ContentMimeType
-      ..ContentType = reference.ContentType
-      ..FileName = reference.FileName;
+      ..ContentMimeType = "application/test"
+      ..ContentType = EpubContentType.OTHER
+      ..FileName = "orthrosFile";
   });
 
   tearDown(() async {


### PR DESCRIPTION
Fixes hashcode computation for several classes with `List` fields.
See #77

Some classes already had the correct implementation(for example `EpubNavigationPoint`). I used them as a reference and tried to preserve the code style.

Old tests passed. Updated tests pass as well.

Also resolves #74(see #75).